### PR TITLE
🚀 反映

### DIFF
--- a/src/app/(authenticated)/search/barcode/page.tsx
+++ b/src/app/(authenticated)/search/barcode/page.tsx
@@ -17,7 +17,7 @@ export default async function SearchBarcode() {
   return (
     <div className="my-auto text-center">
       <p className="ml-3 rotate-12 text-3xl">⚒️</p>
-      <p className="font-noto-emoji text-5xl">🐙</p>
+      <p className="text-5xl">🐙</p>
       <p className="mt-3 text-sm">現在開発中です…！</p>
     </div>
   );

--- a/src/app/_components/ErrorPage/index.tsx
+++ b/src/app/_components/ErrorPage/index.tsx
@@ -15,7 +15,7 @@ export default function ErrorPage({ title, children }: Props) {
       <div className="mt-10 space-y-1">{children}</div>
       <Button asChild>
         <Link className="mx-auto mt-10 block w-fit text-base md:mx-0" href="/">
-          <span className="font-noto-emoji">🐙</span>
+          <span>🐙</span>
           <span className="ml-2">トップページに戻る</span>
         </Link>
       </Button>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -5,7 +5,7 @@ import ErrorPage from "./_components/ErrorPage";
 export default function GlobalError() {
   return (
     <html lang="ja">
-      <body className="bg-background font-noto-emoji text-text">
+      <body className="bg-background text-text">
         <ErrorPage title="Error">
           <p>サーバーでエラーが発生しました</p>
           <p>しばらく時間をおいて、再度お試しください 🙇</p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,15 +2,7 @@ import { twMerge } from "tailwind-merge";
 import "./globals.css";
 import { site } from "@/constants/site";
 import type { Metadata } from "next";
-import { Noto_Color_Emoji } from "next/font/google";
 import localFont from "next/font/local";
-
-const notoEmoji = Noto_Color_Emoji({
-  weight: ["400"],
-  subsets: ["emoji"],
-  display: "swap",
-  variable: "--font-noto-emoji",
-});
 
 const lineSeedJp = localFont({
   src: [
@@ -52,11 +44,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={twMerge(
-          "bg-background text-text",
-          lineSeedJp.className,
-          notoEmoji.variable,
-        )}
+        className={twMerge("bg-background text-text", lineSeedJp.className)}
       >
         {children}
       </body>

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -13,7 +13,7 @@ export function Loading({ title, className }: Props) {
         className,
       )}
     >
-      <p className="animate-bounce cursor-grab font-noto-emoji">₍₍⁽⁽🐙₎₎⁾⁾</p>
+      <p className="animate-bounce cursor-grab">₍₍⁽⁽🐙₎₎⁾⁾</p>
       <p className="text-xs">{title}</p>
     </div>
   );

--- a/src/components/SayTako/index.tsx
+++ b/src/components/SayTako/index.tsx
@@ -14,7 +14,7 @@ export default function SayTako({ message, className }: Props) {
       )}
     >
       <p className="text-xs">{`\\ ${message} /`}</p>
-      <p className="font-noto-emoji">🐙</p>
+      <p>🐙</p>
     </div>
   );
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,9 +8,6 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      fontFamily: {
-        "noto-emoji": "var(--font-noto-emoji)",
-      },
       fontSize: {
         xxs: "0.625rem",
       },


### PR DESCRIPTION
タコのためだけに入れてたけど、以下の理由からありのままのタコをお届けすることにしました

- iOS Safari で Noto Emoji がうまく表示されない
- 絵文字を使う箇所で異体字セレクタのことを考えるのが面倒
- そもそもタコだけにフォントファイルを読み込むのはちょっとオーバーかも