### PR TITLE
🚑 記録済みの書籍以外が検索できない

### DIFF
--- a/src/app/(fullscreen)/search/barcode/_actions/searchFromIsbn.ts
+++ b/src/app/(fullscreen)/search/barcode/_actions/searchFromIsbn.ts
@@ -4,6 +4,7 @@ import { getStatusesByBookIds } from "@/db/queries/status";
 import { auth } from "@/lib/auth";
 import { searchBooksFromNDL } from "@/lib/searchBooks";
 import type { BookType } from "@/types/book";
+import type { ReadingStatus } from "@/types/readingStatus";
 
 export async function searchFromIsbn(
   isbn: string,
@@ -23,14 +24,15 @@ export async function searchFromIsbn(
     return;
   }
 
+  // ライブラリを検索
   const libraryBook = await getStatusesByBookIds(session.user.id, result.books);
 
-  if (libraryBook.length <= 0) {
-    return;
-  }
+  // 自分の読書ステータス
+  const readingStatus: ReadingStatus =
+    libraryBook.length > 0 ? libraryBook[0].status : "none";
 
   return {
     detail: result.books[0],
-    readingStatus: libraryBook[0].status,
+    readingStatus,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ISBNからの書籍検索機能の改善により、書籍の読み取りステータスが常に定義されるようになりました。
- **バグ修正**
	- 書籍が見つからない場合の処理が簡素化され、デフォルトの読み取りステータスが設定されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->