### PR TITLE
🔧 GHPagesにレポートをデプロイするワークフローを追加

### DIFF
--- a/.github/workflows/delete-storybook-vrt-report.yml
+++ b/.github/workflows/delete-storybook-vrt-report.yml
@@ -1,0 +1,59 @@
+name: Delete Storybook VRT Report
+
+on:
+  delete:
+    branches-ignore: [main, develop, gh-pages]
+
+concurrency:
+  group: ${{ github.event.ref }}
+  cancel-in-progress: true
+
+jobs:
+  delete-storybook-vrt-report:
+    name: Delete Storybook VRT Report
+    runs-on: ubuntu-latest
+    env:
+      BRANCH_REPORTS_DIR: reports/${{ github.event.ref }}
+    steps:
+      - name: Checkout GitHub Pages Branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Set Git User
+        # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Check for workflow reports
+        run: |
+          if [ -z "$(ls -A $BRANCH_REPORTS_DIR)" ]; then
+            echo "BRANCH_REPORTS_EXIST="false"" >> $GITHUB_ENV
+          else
+            echo "BRANCH_REPORTS_EXIST="true"" >> $GITHUB_ENV
+          fi
+
+      - name: Delete reports from repo for branch
+        if: ${{ env.BRANCH_REPORTS_EXIST == 'true' }}
+        timeout-minutes: 3
+        run: |
+          cd $BRANCH_REPORTS_DIR/..
+
+          rm -rf ${{ github.event.ref }}
+          git add .
+          git commit -m 🔥 レポートを削除 ${{ github.event.ref }}"
+
+          while true; do
+            git pull --rebase
+            if [ $? -ne 0 ]; then
+              echo "rebaseに失敗"
+              exit 1
+            fi
+
+            git push
+            if [ $? -eq 0 ]; then
+              echo "削除に成功"
+              exit 0
+            fi
+          done

--- a/.github/workflows/delete-storybook-vrt-report.yml
+++ b/.github/workflows/delete-storybook-vrt-report.yml
@@ -45,14 +45,12 @@ jobs:
           git commit -m 🔥 レポートを削除 ${{ github.event.ref }}"
 
           while true; do
-            git pull --rebase
-            if [ $? -ne 0 ]; then
+            if ! git pull --rebase; then
               echo "rebaseに失敗"
               exit 1
             fi
 
-            git push
-            if [ $? -eq 0 ]; then
+            if git push; then
               echo "削除に成功"
               exit 0
             fi

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Download zipped HTML report
       uses: actions/download-artifact@v4
       with:
-        name: playwright-report
+        name: vrt-report
         path: ${{ env.HTML_REPORT_URL_PATH }}
 
     - name: Push HTML Report

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -80,6 +80,7 @@ jobs:
     needs: storybook-vrt
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 60
     concurrency:
       group: ${{ github.ref_name }}
       cancel-in-progress: true
@@ -112,16 +113,15 @@ jobs:
         git commit -m "🍱 テストレポートを追加 ${{ github.run_id }} (attempt:  ${{ github.run_attempt }})"
 
         while true; do
-          git pull --rebase
-          if [ $? -ne 0 ]; then
+          if git pull --rebase; then
+            if git push; then
+              echo "デプロイに成功"
+              exit 0
+            else
+              echo "pushに失敗"
+            fi
+          else
             echo "rebaseに失敗"
-            exit 1
-          fi
-
-          git push
-          if [ $? -eq 0 ]; then
-            echo "デプロイに成功"
-            exit 0
           fi
         done
 

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -1,10 +1,8 @@
 name: Storybook VRT
 
 on:
-  pull_request:
-    branches:
-      - main
-      - develop
+  push:
+    branches-ignore: [main, develop, gh-pages]
 
 jobs:
   storybook-vrt:
@@ -69,3 +67,64 @@ jobs:
           name: vrt-report
           path: playwright-report/
           retention-days: 7
+
+  # レポートを GitHub Pages にデプロイ
+  # https://ysfaran.github.io/blog/2022/09/02/playwright-gh-action-gh-pages/#publish-html-report-to-github-pages
+  deploy-report:
+    name: Deploy VRT Report
+    # テスト失敗時のみ
+    if: needs.storybook-vrt.result == 'failure'
+    needs: storybook-vrt
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    concurrency:
+      group: ${{ github.ref_name }}
+      cancel-in-progress: true
+    env:
+      HTML_REPORT_URL_PATH: reports/${{ github.ref_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+    steps:
+    - name: Checkout GitHub Pages Branch
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+
+    - name: Set Git User
+      # see: https://github.com/actions/checkout/issues/13#issuecomment-724415212
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Download zipped HTML report
+      uses: actions/download-artifact@v4
+      with:
+        name: playwright-report
+        path: ${{ env.HTML_REPORT_URL_PATH }}
+
+    - name: Push HTML Report
+      timeout-minutes: 3
+      # commit report, then try push-rebase-loop until it's able to merge the HTML report to the gh-pages branch
+      # this is necessary when this job is running at least twice at the same time (e.g. through two pushes at the same time)
+      run: |
+        git add .
+        git commit -m "🍱 テストレポートを追加 ${{ github.run_id }} (attempt:  ${{ github.run_attempt }})"
+
+        while true; do
+          git pull --rebase
+          if [ $? -ne 0 ]; then
+            echo "rebaseに失敗"
+            exit 1
+          fi
+
+          git push
+          if [ $? -eq 0 ]; then
+            echo "デプロイに成功"
+            exit 0
+          fi
+        done
+
+    # TODO: PRにコメントを残すようにしたい
+    - name: Output Report URL as Workflow Annotation
+      run: |
+        FULL_HTML_REPORT_URL=https://yondako.github.io/yondako/$HTML_REPORT_URL_PATH
+
+        echo "::notice title=📋 Published Playwright Test Report::$FULL_HTML_REPORT_URL"

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -73,7 +73,7 @@ jobs:
   deploy-report:
     name: Deploy VRT Report
     # テスト失敗時のみ
-    if: needs.storybook-vrt.result == 'failure'
+    if: failure()
     needs: storybook-vrt
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -72,6 +72,9 @@ jobs:
   # https://ysfaran.github.io/blog/2022/09/02/playwright-gh-action-gh-pages/#publish-html-report-to-github-pages
   deploy-report:
     name: Deploy VRT Report
+    permissions:
+      contents: write
+      pull-requests: write
     # テスト失敗時のみ
     if: failure()
     needs: storybook-vrt

--- a/src/app/_components/ErrorPage/index.stories.tsx
+++ b/src/app/_components/ErrorPage/index.stories.tsx
@@ -12,6 +12,6 @@ type Story = StoryObj<typeof ErrorPage>;
 export const Default: Story = {
   args: {
     title: "エラータイトル",
-    children: <p>テスト</p>,
+    children: <p>ここにテキストを入れる</p>,
   },
 };

--- a/src/app/_components/ErrorPage/index.stories.tsx
+++ b/src/app/_components/ErrorPage/index.stories.tsx
@@ -12,6 +12,6 @@ type Story = StoryObj<typeof ErrorPage>;
 export const Default: Story = {
   args: {
     title: "エラータイトル",
-    children: <p>ここにテキストを入れる</p>,
+    children: <p>テスト</p>,
   },
 };

--- a/src/app/_components/ErrorPage/index.stories.tsx
+++ b/src/app/_components/ErrorPage/index.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof ErrorPage>;
 
 export const Default: Story = {
   args: {
-    title: "エラータイトル",
+    title: "タイトル",
     children: <p>ここにテキストを入れる</p>,
   },
 };


### PR DESCRIPTION
参考: https://ysfaran.github.io/blog/2022/09/02/playwright-gh-action-gh-pages/#publish-html-report-to-github-pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ブランチ削除時にStorybook VRTレポートを自動的にクリーンアップする新しいワークフローを追加しました。
  - Storybook VRTのトリガーイベントを`pull_request`から`push`に変更し、失敗時にレポートをデプロイする新しいジョブを追加しました。
  - `ErrorPage`コンポーネントのStorybook設定で、表示テキストを更新しました。

- **バグ修正**
  - レポートのプッシュ操作にリベースループを追加し、マージコンフリクトを処理します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->