### PR TITLE
🚑️ 書影部分のCSSを修正

### DIFF
--- a/src/components/BookCard/index.stories.tsx
+++ b/src/components/BookCard/index.stories.tsx
@@ -6,12 +6,7 @@ const meta: Meta<typeof BookCard> = {
   title: "Common/BookCard",
   component: BookCard,
   render: (args) => {
-    return (
-      // TODO: 書影に位置が justify-items-center に依存してるっぽいので直したい
-      <div className="grid w-96 grid-cols-1 justify-items-center">
-        <BookCard {...args} />
-      </div>
-    );
+    return <BookCard {...args} />;
   },
 };
 

--- a/src/components/BookCard/index.stories.tsx
+++ b/src/components/BookCard/index.stories.tsx
@@ -6,7 +6,11 @@ const meta: Meta<typeof BookCard> = {
   title: "Common/BookCard",
   component: BookCard,
   render: (args) => {
-    return <BookCard {...args} />;
+    return (
+      <div className="w-96">
+        <BookCard {...args} />
+      </div>
+    );
   },
 };
 

--- a/src/components/BookCard/index.tsx
+++ b/src/components/BookCard/index.tsx
@@ -61,7 +61,7 @@ export default function BookCard({ data }: Props) {
       <IconDotsVertical className="pointer-events-none absolute right-5 bottom-6 block h-4 w-4 rounded-2xl" />
 
       <BookThumbnail
-        className="pointer-events-none absolute top-4 left-4 w-28 border-4 border-tertiary-background shadow-xl"
+        className="-top-4 pointer-events-none absolute left-4 w-28 border-4 border-tertiary-background shadow-xl"
         isbn={data.detail.isbn}
         jpeCode={data.detail.jpeCode}
       />

--- a/src/components/BookCard/index.tsx
+++ b/src/components/BookCard/index.tsx
@@ -29,9 +29,9 @@ export default function BookCard({ data }: Props) {
   };
 
   return (
-    <div className="relative w-full text-left text-primary-foreground">
+    <div className="relative mt-8 w-full text-left text-primary-foreground">
       <BookDetail bookDetailProps={{ data, ...formProps }}>
-        <button className="mt-8 flex h-40 w-full flex-col justify-between overflow-hidden rounded-2xl bg-tertiary-background p-4 pl-36 text-left">
+        <button className="flex h-40 w-full flex-col justify-between overflow-hidden rounded-2xl bg-tertiary-background p-4 pl-36 text-left">
           <div className="space-y-1">
             <h3 className="palt line-clamp-3 font-bold text-sm leading-5">
               {data.detail.title}


### PR DESCRIPTION
- **🚑 (components/BookCard) 書影に位置が justify-items-center に依存している**
- **🚑 (components/BookCard): 外側のマージンが何故か内側から当てられていた**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- なし
- **バグ修正**
	- なし
- **ドキュメント**
	- なし
- **リファクタ**
	- `BookCard`コンポーネントのレイアウトとスタイルを調整
- **スタイル**
	- コンポーネントの上下のマージンを変更
	- サムネイルの位置を調整
- **テスト**
	- なし
- **雑務**
	- なし
- **リバート**
	- なし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->