### PR TITLE
🚑 書誌識別子が無い書籍が検索に沢山ヒットすると空のページが混じることがある

### DIFF
--- a/src/actions/updateReadingStatus.ts
+++ b/src/actions/updateReadingStatus.ts
@@ -45,6 +45,11 @@ export async function updateReadingStatus(
     } else if (bookIdentifiers.isbn) {
       // NDL書誌IDが無い場合はISBNで検索
       opts.isbn = bookIdentifiers.isbn;
+    } else {
+      // どちらも無い場合はエラー
+      return {
+        error: "この書籍は未対応のため登録できません",
+      };
     }
 
     const results = await searchBooksFromNDL(opts);

--- a/src/lib/ndl/index.ts
+++ b/src/lib/ndl/index.ts
@@ -42,8 +42,9 @@ export async function searchBooksFromNDL(
     "iss-ndl-opac iss-ndl-opac-inprocess iss-ndl-opac-national jpro-book jpro-online",
   );
 
-  // 対象を図書に絞る
-  endpoint.searchParams.append("mediatype", "books");
+  // メディアタイプの指定
+  // (資料形態: 紙)
+  endpoint.searchParams.append("mediatype", "booklet");
 
   try {
     const res = await fetch(endpoint);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- 読書状況の更新時に、識別子（NDL書誌ID、ISBN）が提供されない場合のエラーハンドリングを改善
	- NDLでの書籍検索時のメディアタイプパラメータを調整し、検索精度を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->