### PR TITLE
README の環境構築を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ bun install
 
 ```sh
 bun run wrangler d1 create yondako_dev
-bun run generate:schema ./src/db/schema/*
-bun run wrangler d1 migrations apply yondako --local
+bun run generate:schema "./src/db/schema/*"
+bun run wrangler d1 migrations apply yondako_dev --local
 ```
 
 ### `wrangler.toml` の設定
@@ -34,6 +34,7 @@ pages_build_output_dir = ".vercel/output/static"
 binding = "DB"
 database_name = "yondako_dev"
 database_id = "<database_idを指定>"
+migrations_dir = "src/db/migrations"
 ```
 
 ### 起動


### PR DESCRIPTION
- generate:schema でエラーが出たので引数を "" で囲んだ。
- migrations でエラーが出たので migrations_dir を指定した。
- DB名は yondako_dev に揃えるのが良さそうなので migrations コマンドを揃えた。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **ドキュメント**
	- データベースのセットアップ手順を更新
	- マイグレーションコマンドを開発環境用に調整
	- `wrangler.toml` の設定を更新し、マイグレーションディレクトリを指定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->