### PR TITLE
👍 書籍登録時のロジックを調整

### DIFF
--- a/src/constants/db.ts
+++ b/src/constants/db.ts
@@ -1,2 +1,2 @@
 /** 書誌データの更新チェックの最大回数 */
-export const MAX_UPDATE_CHECK_COUNT = 5;
+export const MAX_UPDATE_CHECK_COUNT = 20;

--- a/src/lib/ndl/index.ts
+++ b/src/lib/ndl/index.ts
@@ -39,7 +39,7 @@ export async function searchBooksFromNDL(
   // (国立国会図書館蔵書, 国立国会図書館新着書誌情報, 国立国会図書館全国書誌情報, JPRO)
   endpoint.searchParams.append(
     "dpid",
-    "iss-ndl-opac iss-ndl-opac-inprocess iss-ndl-opac-national jpro-book jpro-online",
+    "iss-ndl-opac iss-ndl-opac-inprocess iss-ndl-opac-national jpro-book",
   );
 
   // メディアタイプの指定

--- a/src/lib/ndl/parse.ts
+++ b/src/lib/ndl/parse.ts
@@ -191,26 +191,24 @@ export function parseOpenSearchXml(xml: string): OpenSearchResponse {
 export function isOlderThanHalfYear(
   publishedDateStr: string | undefined,
 ): boolean {
-  const publishedDate = publishedDateStr
-    ? new Date(publishedDateStr)
-    : undefined;
-
-  if (!publishedDate) {
+  if (!publishedDateStr) {
     return false;
   }
 
-  const now = new Date();
+  try {
+    const publishedDate = new Date(publishedDateStr);
 
-  // JSTに変換
-  const publishedDateUtc = new Date(
-    publishedDate.getTime() - 9 * 60 * 60 * 1000,
-  );
+    // 無効な日付の場合
+    if (Number.isNaN(publishedDate.getTime())) {
+      return false;
+    }
 
-  const halfYearAgo = new Date(
-    now.getFullYear(),
-    now.getMonth() - 6,
-    now.getDate(),
-  );
+    const now = new Date();
+    const halfYearAgo = new Date(now);
+    halfYearAgo.setMonth(now.getMonth() - 6);
 
-  return publishedDateUtc < halfYearAgo;
+    return publishedDate < halfYearAgo;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
- **👍 5 -> 20回に変更**
- **👍 書籍登録時のロジックを調整**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 書籍の更新チェック回数の最大値を5から20に増加
	- 出版日に基づいて更新チェックのロジックを改善

- **バグ修正**
	- NDLデータプロバイダのリストから`jpro-online`を削除

- **テスト**
	- 新しい関数`isOlderThanHalfYear`のテストケースを追加
	- 書籍の更新チェックに関する検証テストを実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->