### PR TITLE
🚑️ 新刊書誌データの更新がWorkersの制限に引っかかって動いていない

### DIFF
--- a/.github/workflows/trigger-update-books.yml
+++ b/.github/workflows/trigger-update-books.yml
@@ -10,6 +10,14 @@ jobs:
   trigger-update-books:
     runs-on: ubuntu-latest
     steps:
-      - name: Call Update API
-        run: |
-          curl -X POST -H "X-API-SECRET-KEY: ${{ secrets.PROD_API_SECRET_KEY }}" https://yondako.com/api/books/update-missing-ndlbibid
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+          cache: true
+
+      - name: Run script
+        run: bun ./scripts/trigger-update-books.ts

--- a/scripts/trigger-update-books.ts
+++ b/scripts/trigger-update-books.ts
@@ -1,0 +1,30 @@
+import { site } from "../src/constants/site";
+
+const baseUrl = site.url;
+
+const headers: HeadersInit = {
+  "X-API-SECRET-KEY": process.env.API_SECRET_KEY || "",
+};
+
+// 更新確認が必要な書籍IDを取得
+const res = await fetch(new URL("/api/books/updates-needed", baseUrl), {
+  headers,
+});
+
+const bookIds = (await res.json()) as string[];
+
+// 10件ずつループ
+for (let i = 0; i < bookIds.length; i += 10) {
+  const ids = bookIds.slice(i, i + 10);
+
+  await fetch(new URL("/api/books/update", baseUrl), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({ ids }),
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+}

--- a/scripts/trigger-update-books.ts
+++ b/scripts/trigger-update-books.ts
@@ -13,11 +13,18 @@ const res = await fetch(new URL("/api/books/updates-needed", baseUrl), {
 
 const bookIds = (await res.json()) as string[];
 
-// 10件ずつループ
-for (let i = 0; i < bookIds.length; i += 10) {
-  const ids = bookIds.slice(i, i + 10);
+console.log(`更新対象の書籍: ${bookIds.length}件`);
 
-  await fetch(new URL("/api/books/update", baseUrl), {
+// 20件ずつループ
+const STEP = 20;
+
+for (let i = 0; i < bookIds.length; i += STEP) {
+  const ids = bookIds.slice(i, i + STEP);
+  console.log(
+    `更新をリクエスト: ${i / 10 + 1}/${Math.ceil(bookIds.length / 10)}`,
+  );
+
+  const updateRes = await fetch(new URL("/api/books/update", baseUrl), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -25,6 +32,10 @@ for (let i = 0; i < bookIds.length; i += 10) {
     },
     body: JSON.stringify({ ids }),
   });
+
+  if (!updateRes.ok) {
+    throw new Error(`HTTP error! status: ${updateRes.status}`);
+  }
 
   await new Promise((resolve) => setTimeout(resolve, 1000));
 }

--- a/src/actions/updateReadingStatus.ts
+++ b/src/actions/updateReadingStatus.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { createBook, getBook } from "@/db/queries/book";
+import { createBook, fetchBook } from "@/db/queries/book";
 import { upsertReadingStatus } from "@/db/queries/status";
 import { auth } from "@/lib/auth";
 import { type SearchOptions, searchBooksFromNDL } from "@/lib/ndl";
@@ -31,7 +31,7 @@ export async function updateReadingStatus(
   }
 
   // Dbに登録されているか確認
-  let bookDetail = await getBook(bookIdentifiers);
+  let bookDetail = await fetchBook(bookIdentifiers);
 
   // DBに無い場合登録する
   if (!bookDetail) {

--- a/src/app/api/books/update/_libs/notify.ts
+++ b/src/app/api/books/update/_libs/notify.ts
@@ -15,14 +15,16 @@ export async function notifyUpdateResult({
   webhookUrl,
 }: NotifyUpdateResultOpts) {
   const updatedStatus =
-    updatedBookIds.length > 0 ? `\`${updatedBookIds.join(", ")}\`` : "なし";
+    updatedBookIds.length > 0
+      ? `\`\`\`\n${updatedBookIds.join("\n")}\`\`\``
+      : "なし";
 
   const unupdatedStatus =
-    unupdatedBookIds.length > 0 ? `\`${unupdatedBookIds.join(", ")}\`` : "なし";
+    unupdatedBookIds.length > 0
+      ? `\`\`\`\n${unupdatedBookIds.join("\n")}\`\`\``
+      : "なし";
 
-  const text = `新刊書誌データの更新確認が完了
-
-*🆙 更新済み*
+  const text = `*🆙 更新済み*
 ${updatedStatus}
 
 *📚️ 未更新*

--- a/src/app/api/books/update/_libs/notify.ts
+++ b/src/app/api/books/update/_libs/notify.ts
@@ -1,6 +1,6 @@
 type NotifyUpdateResultOpts = {
-  updatedBooksCount: number;
-  unupdatedBooksCount: number;
+  updatedBookIds: string[];
+  unupdatedBookIds: string[];
   webhookUrl: string;
 };
 
@@ -10,14 +10,24 @@ type NotifyUpdateResultOpts = {
  * @param unupdatedBooksCount 未更新書籍数
  */
 export async function notifyUpdateResult({
-  updatedBooksCount,
-  unupdatedBooksCount,
+  updatedBookIds,
+  unupdatedBookIds,
   webhookUrl,
 }: NotifyUpdateResultOpts) {
-  const text = `新刊書誌データの更新確認が完了しました
+  const updatedStatus =
+    updatedBookIds.length > 0 ? `\`${updatedBookIds.join(", ")}\`` : "なし";
 
-- 更新済み: ${updatedBooksCount} 件
-- 未更新: ${unupdatedBooksCount} 件`;
+  const unupdatedStatus =
+    unupdatedBookIds.length > 0 ? `\`${unupdatedBookIds.join(", ")}\`` : "なし";
+
+  const text = `新刊書誌データの更新確認が完了
+
+*🆙 更新済み*
+${updatedStatus}
+
+*📚️ 未更新*
+${unupdatedStatus}
+`;
 
   const payload = {
     text,

--- a/src/app/api/books/update/route.ts
+++ b/src/app/api/books/update/route.ts
@@ -1,9 +1,17 @@
 import { getRequestContext } from "@cloudflare/next-on-pages";
 import type { NextRequest } from "next/server";
+import { array, maxLength, object, pipe, safeParse, string } from "valibot";
 import { updateNewReleaseBooks } from "./_libs/checkAndUpdateBook";
 
 export const runtime = "edge";
 
+const requestBodySchema = object({
+  ids: pipe(array(string()), maxLength(10)),
+});
+
+/**
+ * 新刊書誌データの更新を行う
+ */
 export async function POST(req: NextRequest) {
   const accessKey = req.headers.get("X-API-SECRET-KEY");
 
@@ -13,9 +21,19 @@ export async function POST(req: NextRequest) {
     });
   }
 
+  // リクエストBodyをパース
+  const body = await req.json();
+  const { success, output } = safeParse(requestBodySchema, body);
+
+  if (!success) {
+    return new Response("Bad Request", {
+      status: 400,
+    });
+  }
+
   const { ctx } = getRequestContext();
 
-  ctx.waitUntil(updateNewReleaseBooks());
+  ctx.waitUntil(updateNewReleaseBooks(output.ids));
 
   return new Response("OK", {
     status: 200,

--- a/src/app/api/books/updates-needed/route.ts
+++ b/src/app/api/books/updates-needed/route.ts
@@ -1,0 +1,25 @@
+import { getBooksPossiblyNewReleases } from "@/db/queries/book";
+import type { NextRequest } from "next/server";
+
+export const runtime = "edge";
+
+/**
+ * 新刊書籍の書誌IDを返す
+ */
+export async function GET(req: NextRequest) {
+  const accessKey = req.headers.get("X-API-SECRET-KEY");
+
+  if (accessKey !== process.env.API_SECRET_KEY) {
+    return new Response("Forbidden", {
+      status: 403,
+    });
+  }
+
+  // 登録済みの新刊の書誌データを取得
+  const targetBooks = await getBooksPossiblyNewReleases();
+  const ids = targetBooks.map((book) => book.id);
+
+  return new Response(JSON.stringify(ids), {
+    status: 200,
+  });
+}

--- a/src/db/queries/book.ts
+++ b/src/db/queries/book.ts
@@ -13,11 +13,11 @@ import { createAuthor } from "./author";
 import { createPublisher } from "./publisher";
 
 /**
- * 書籍データを取得
+ * 識別子から書籍データを取得
  * @param identifiers 書籍識別子
  * @returns 書籍データ
  */
-export async function getBook({
+export async function fetchBook({
   ndlBibId,
   isbn,
 }: BookIdentifiers): Promise<BookDetail | undefined> {
@@ -81,6 +81,19 @@ export async function getBook({
             .filter((x) => typeof x === "string")
         : undefined,
   };
+}
+
+/**
+ * 書籍IDから書籍データを取得 (著者・出版社情報を含まない)
+ * @param bookIds 書籍IDの配列
+ * @returns 書籍データ
+ */
+export async function fetchSimpleBooksByIds(
+  bookIds: string[],
+): Promise<Omit<BookDetail, "authors" | "publisher">[]> {
+  return db.query.books.findMany({
+    where: inArray(dbSchema.books.id, bookIds),
+  });
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     "**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "scripts"]
 }


### PR DESCRIPTION
- **💥 新刊書誌データ更新周りのAPIを変更**
- **🔧 更新用のスクリプトを追加**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- 本の更新に関する新しいAPIエンドポイントを追加
	- 更新が必要な本のIDを取得するエンドポイントを実装
	- 本のIDを一括で取得・更新するスクリプトを導入

- **バグ修正**
	- 本の更新プロセスのエラーハンドリングを改善
	- リクエストボディのバリデーション機能を追加

- **リファクタリング**
	- 本の取得と更新のロジックを最適化
	- スクリプトと API のアプローチを再構築

- **その他の変更**
	- GitHub Workflow の更新
	- TypeScript の設定を調整

<!-- end of auto-generated comment: release notes by coderabbit.ai -->