### PR TITLE
🚑 Safariで書影が縦に長くなるときがある

### DIFF
--- a/src/components/BookCard/index.tsx
+++ b/src/components/BookCard/index.tsx
@@ -61,7 +61,7 @@ export default function BookCard({ data }: Props) {
       <IconDotsVertical className="pointer-events-none absolute right-5 bottom-6 block h-4 w-4 rounded-2xl" />
 
       <BookThumbnail
-        className="-top-4 pointer-events-none absolute left-4 w-28 border-4 border-tertiary-background shadow-xl"
+        className="-top-4 pointer-events-none absolute left-4 h-full w-28 border-4 border-tertiary-background shadow-xl"
         isbn={data.detail.isbn}
         jpeCode={data.detail.jpeCode}
       />

--- a/src/components/BookThumbnail/index.tsx
+++ b/src/components/BookThumbnail/index.tsx
@@ -60,7 +60,7 @@ function Wrapper({
   return (
     <div
       className={twMerge(
-        "flex aspect-64/91 items-center justify-center overflow-hidden rounded-2xl bg-secondary-background",
+        "flex aspect-[64/91] items-center justify-center overflow-hidden rounded-2xl bg-secondary-background",
         className,
       )}
     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
	- 商品画像の表示を、固定サイズからコンテナ全体に合わせたダイナミックなサイズに変更しました。
	- アスペクト比の指定方法を最新の形式に更新し、スタイリングの一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->