### PR TITLE
💄 お知らせカードをスリムなデザインに

### DIFF
--- a/src/app/(framed)/news/_components/NewsCard/index.tsx
+++ b/src/app/(framed)/news/_components/NewsCard/index.tsx
@@ -16,20 +16,23 @@ export default function NewsCard({
 
   return (
     <a
-      className="block space-y-3 rounded-2xl bg-tertiary-background p-6 transition hover:brightness-95 md:space-y-4 md:p-8"
+      className="flex items-center space-x-6 rounded-2xl bg-tertiary-background p-8 transition hover:brightness-95"
       href={href}
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`${title}の詳細を見る`}
     >
-      <p className="text-4xl md:text-5xl">{emoji}</p>
-      <p className="font-bold text-base md:text-lg">{title}</p>
-      <div className="flex items-center justify-between text-xs">
-        <span className="text-secondary-foreground">{publishedAt}</span>
-        <div className="flex space-x-1">
-          {tags.map((tag) => (
-            <Tag key={tag} name={tag} />
-          ))}
+      <p className="h-fit text-5xl">{emoji}</p>
+
+      <div className="w-full">
+        <p className="font-bold text-base">{title}</p>
+        <div className="mt-2 flex items-center justify-between text-xs">
+          <span className="text-secondary-foreground ">{publishedAt}</span>
+          <div className="flex space-x-1">
+            {tags.map((tag) => (
+              <Tag key={tag} name={tag} />
+            ))}
+          </div>
         </div>
       </div>
     </a>

--- a/src/app/api/books/update/_libs/notify.ts
+++ b/src/app/api/books/update/_libs/notify.ts
@@ -15,14 +15,10 @@ export async function notifyUpdateResult({
   webhookUrl,
 }: NotifyUpdateResultOpts) {
   const updatedStatus =
-    updatedBookIds.length > 0
-      ? `\`\`\`\n${updatedBookIds.join("\n")}\`\`\``
-      : "なし";
+    updatedBookIds.length > 0 ? updatedBookIds.join("\n") : "なし";
 
   const unupdatedStatus =
-    unupdatedBookIds.length > 0
-      ? `\`\`\`\n${unupdatedBookIds.join("\n")}\`\`\``
-      : "なし";
+    unupdatedBookIds.length > 0 ? unupdatedBookIds.join("\n") : "なし";
 
   const text = `*🆙 更新済み*
 ${updatedStatus}


### PR DESCRIPTION
- **👍 メッセージ形式を調整**
- **💄 お知らせカードをスリムなデザインに**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
	- ニュースカードのレイアウトと余白を調整し、要素の配置と視認性を向上しました。
	- 書籍アップデートの通知メッセージの出力形式を改善し、情報の読みやすさを高めました。 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->