### PR TITLE
🔧 install-depsにブラウザを指定

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -28,4 +28,4 @@ runs:
     - name: Install just Playwright's dependencies
       shell: bash
       if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
-      run: bunx playwright install-deps
+      run: bunx playwright install-deps chromium webkit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Playwrightの依存関係インストール手順を更新し、ChromiumおよびWebKitブラウザのセットアップが明示的に行われるよう改善しました。これにより、クロスブラウザテスト環境の安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->