### PR TITLE
🔧 chromiumの依存関係はキャッシュできてる気がする

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -28,4 +28,4 @@ runs:
     - name: Install just Playwright's dependencies
       shell: bash
       if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
-      run: bunx playwright install-deps chromium webkit
+      run: bunx playwright install-deps webkit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Playwrightのセットアップ時に、従来の複数ブラウザ向け依存関係のインストールからWebKitのみのインストールへ変更しました。これにより、キャッシュが有効な場合のインストールプロセスが効率化され、全体のセットアップ時間の短縮が期待されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->