### PR TITLE
🩹 検索の件数を減らすことで暫定的に対処

### DIFF
--- a/src/app/(framed)/search/_components/SearchResult/index.tsx
+++ b/src/app/(framed)/search/_components/SearchResult/index.tsx
@@ -9,7 +9,8 @@ import type { NDC } from "@/types/ndc";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { headers } from "next/headers";
 
-const SEARCH_COUNT = 48;
+// NOTE: あまり大きいと getStatusesByBookIds 内で D1_ERROR: too many SQL variables が発生する
+const SEARCH_COUNT = 24;
 
 export type SearchResultProps = {
   query: string;
@@ -71,7 +72,7 @@ export async function SearchResult({
         className="mt-16"
         title="見つかりませんでした"
         decoration={
-          <span className="-right-8 absolute top-0 text-5xl">❓️</span>
+          <span className="-right-8 absolute top-0 text-5xl">❓</span>
         }
       >
         <p className="mt-3">該当する書籍が見つかりませんでした。</p>
@@ -79,6 +80,8 @@ export async function SearchResult({
       </MessageTako>
     );
   }
+
+  console.log("search result", result.books.length);
 
   const items = await getStatusesByBookIds(
     env.DB,

--- a/src/db/queries/status.ts
+++ b/src/db/queries/status.ts
@@ -208,8 +208,6 @@ export async function getStatusesByBookIds(
       .map((b) => normalizeIsbn(b.isbn))
       .filter((id) => typeof id === "string");
 
-    console.log(ndlBibIds, isbns);
-
     // NDL書誌IDかISBNで書籍を検索
     const bookIds = db.$with("book_ids").as(
       db
@@ -220,6 +218,7 @@ export async function getStatusesByBookIds(
         })
         .from(dbSchema.books)
         .where(
+          // FIXME: D1の制限であまり個数の多い配列を渡すと D1_ERROR: too many SQL variables が発生する
           or(
             inArray(dbSchema.books.ndlBibId, ndlBibIds),
             // NOTE: JPRO提供のデータはハイフンがないが、NDL提供のデータはハイフンがあるため


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 検索時の「D1_ERROR: too many SQL variables」エラーを回避するため、検索結果の最大表示件数を48件から24件に変更しました。
  - 検索結果が見つからない場合の絵文字表示をシンプルな「❓」に変更しました。

- **その他**
  - 検索結果件数のデバッグ用ログを追加し、不要なデバッグログを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->