### PR TITLE
fix: library filter search triggers only on Enter key press

### DIFF
--- a/src/app/(framed)/library/[status]/_components/LibraryBookList/Filter.tsx
+++ b/src/app/(framed)/library/[status]/_components/LibraryBookList/Filter.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useDebouncedCallback } from "use-debounce";
 import IconSortAsc from "@/assets/icons/sort-ascending.svg";
 import IconSortDesc from "@/assets/icons/sort-descending.svg";
 import Button from "@/components/Button";
@@ -21,11 +20,10 @@ export default function Filter({ isOrderAsc }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const debounced = useDebouncedCallback((value) => {
-    const keyword = String(value).trim();
-
+  const handleSearch = (value: string) => {
+    const keyword = value.trim();
     router.replace(keyword === "" ? removeKeywordParam(searchParams) : createFilterSearchParams(searchParams, keyword));
-  }, 600);
+  };
 
   const IconSort = isOrderAsc ? IconSortAsc : IconSortDesc;
   const nextOrder: Order = isOrderAsc ? "desc" : "asc";
@@ -36,7 +34,11 @@ export default function Filter({ isOrderAsc }: Props) {
         className="grow text-sm sm:max-w-64 lg:text-xs"
         placeholder="タイトルの一部"
         defaultValue={searchParams.get("q") ?? ""}
-        onChange={(e) => debounced(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            handleSearch(e.currentTarget.value);
+          }
+        }}
         search
       />
 


### PR DESCRIPTION
## Summary
- Remove useDebouncedCallback to prevent auto-search during text conversion
- Add onKeyDown handler to search only when Enter is pressed
- Fixes issue #446 where Japanese IME conversion triggered unwanted searches

## Changes
Modified `src/app/(framed)/library/[status]/_components/LibraryBookList/Filter.tsx` to remove debounced auto-search and trigger search only on Enter key press.

Fixes #446

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * ライブラリの検索体験を更新。入力ごとの即時検索やディレイ挙動を廃止し、Enterキーで検索を実行する方式に変更。キーワードの前後空白は自動的に除去して結果に反映します。ページ表示の更新動作は維持し、ソートボタンの表示・動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->