### PR TITLE
Add "すべて" (All) tab to library page

### DIFF
--- a/src/app/(framed)/library/[status]/page.tsx
+++ b/src/app/(framed)/library/[status]/page.tsx
@@ -10,7 +10,7 @@ import { generateMetadataTitle } from "@/lib/metadata";
 import { createSignInPath } from "@/lib/path";
 import { type Order, orderSchema } from "@/types/order";
 import { pageIndexSchema } from "@/types/page";
-import { type ReadingStatus, readingStatusSchemaWithoutNone } from "@/types/readingStatus";
+import { type ReadingStatus, libraryReadingStatusSchema } from "@/types/readingStatus";
 import { LibraryBookList } from "./_components/LibraryBookList";
 import { SwipeableTabView } from "./_components/SwipeableTabView";
 import Tab from "./_components/Tab";
@@ -32,7 +32,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params;
   const readingStatus = readingStatusMetadata.get(params.status);
 
-  if (!readingStatus || !is(readingStatusSchemaWithoutNone, params.status)) {
+  if (!readingStatus || !is(libraryReadingStatusSchema, params.status)) {
     notFound();
   }
 
@@ -58,7 +58,7 @@ export default async function Library(props: Props) {
     redirect(createSignInPath(`/library/${params.status}`));
   }
 
-  if (!is(readingStatusSchemaWithoutNone, params.status)) {
+  if (!is(libraryReadingStatusSchema, params.status)) {
     notFound();
   }
 

--- a/src/constants/library-message.ts
+++ b/src/constants/library-message.ts
@@ -7,4 +7,5 @@ export const LIBRARY_MESSAGE = new Map<ReadingStatus, string>([
   ["read", "ﾅﾆﾓﾅｲ"],
   ["want_read", "ｽｯｷﾘ"],
   ["none", LIBRARY_MESSAGE_NONE],
+  ["all", "ﾅﾆﾓﾅｲ"],
 ]);

--- a/src/constants/status.tsx
+++ b/src/constants/status.tsx
@@ -3,6 +3,8 @@ import IconBook from "@/assets/icons/book.svg";
 import IconBookFilled from "@/assets/icons/book-filled.svg";
 import IconBookmark from "@/assets/icons/bookmark.svg";
 import IconBookmarkFilled from "@/assets/icons/bookmark-filled.svg";
+import IconBookmarks from "@/assets/icons/bookmarks.svg";
+import IconBookmarksFilled from "@/assets/icons/bookmarks-filled.svg";
 import IconMoodEmpty from "@/assets/icons/mood-empty.svg";
 import IconMoodEmptyFilled from "@/assets/icons/mood-empty-filled.svg";
 import IconSquareCheck from "@/assets/icons/square-check.svg";
@@ -51,6 +53,14 @@ export const readingStatusMetadata = new Map<ReadingStatus, ReadingStatusMetadat
       IconFilled: IconSquareCheckFilled,
     },
   ],
+  [
+    "all",
+    {
+      label: "すべて",
+      IconSolid: IconBookmarks,
+      IconFilled: IconBookmarksFilled,
+    },
+  ],
 ]);
 
-export const readingStatusOrder: ReadingStatus[] = ["want_read", "reading", "read"];
+export const readingStatusOrder: ReadingStatus[] = ["all", "want_read", "reading", "read"];

--- a/src/db/queries/status.ts
+++ b/src/db/queries/status.ts
@@ -68,6 +68,12 @@ export async function searchBooksFromLibrary(
     : undefined;
 
   try {
+    // "all"の場合は、want_read, reading, readの3つのステータスを含める
+    const statusCondition =
+      status === "all"
+        ? inArray(dbSchema.readingStatuses.status, ["want_read", "reading", "read"])
+        : eq(dbSchema.readingStatuses.status, status);
+
     const results = db.$with("results").as(
       db
         .select({
@@ -79,7 +85,7 @@ export async function searchBooksFromLibrary(
           },
         })
         .from(dbSchema.readingStatuses)
-        .where(and(eq(dbSchema.readingStatuses.userId, userId), eq(dbSchema.readingStatuses.status, status)))
+        .where(and(eq(dbSchema.readingStatuses.userId, userId), statusCondition))
         .innerJoin(
           dbSchema.books,
           and(

--- a/src/types/readingStatus.ts
+++ b/src/types/readingStatus.ts
@@ -3,7 +3,7 @@ import { picklist } from "valibot";
 /**
  * 読書ステータス
  */
-export const readingStatusValues = ["none", "want_read", "reading", "read"] as const;
+export const readingStatusValues = ["none", "want_read", "reading", "read", "all"] as const;
 
 /**
  * 読書ステータス
@@ -15,3 +15,6 @@ export const readingStatusSchema = picklist(readingStatusValues);
 
 // "none"を除いた読書ステータスのスキーマ
 export const readingStatusSchemaWithoutNone = picklist(readingStatusValues.filter((v) => v !== "none"));
+
+// ライブラリページで使用される読書ステータスのスキーマ ("none"を除く)
+export const libraryReadingStatusSchema = picklist(readingStatusValues.filter((v) => v !== "none"));


### PR DESCRIPTION
## Summary

This PR adds a new "すべて" (All) tab to the library page that displays all books across all reading statuses.

## Changes

- Added "all" status to ReadingStatus type
- Added "すべて" tab with bookmarks icon to status metadata
- Updated readingStatusOrder to include "all" as the first tab
- Modified database query to fetch books from all statuses when "all" is selected
- Updated page validation to support "all" status
- Added empty state message for "all" status

## Testing

- [ ] Verify the "すべて" tab appears as the first tab
- [ ] Verify all books from all statuses are displayed
- [ ] Verify books are sorted by recently updated
- [ ] Verify swipe navigation works with the new tab
- [ ] Verify search and filtering work correctly

Resolves #172

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * ライブラリに新ステータス「すべて」を追加。フィルタで全件（「読みたい」「読書中」「読了」）を一括表示可能に。
  * ステータスの表示順を先頭に「すべて」を配置し、選択しやすく改善。
  * 「すべて」用のラベル（「すべて」）と対応アイコンを追加。
  * 「すべて」選択時のメッセージを追加（表示文言: 「ﾅﾆﾓﾅｲ」）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->